### PR TITLE
fixed css getSelectorToken when selector like `template, /* 1 */ [hidden]`, comment bewteen two selector, and second selector start with `[`, compiled result is `template, /* 1 */ [[hidden]`,it get one more `[` to cause the bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,8 @@ lib/
 
 web/app/
 web/node_modules
+
+package-lock.json
+
+# For WebStorm
+.idea

--- a/src/lang/css/tokenize.js
+++ b/src/lang/css/tokenize.js
@@ -126,7 +126,7 @@ export default class extends BaseTokenize {
         tmpValue += this.getCommentToken(1, false).value;
         continue;
       }
-      if(tmpValue){
+      if(tmpValue && code !== 0x5b){
         tmpValue += chr;
         tmpFlag = true;
       }


### PR DESCRIPTION
fixed css getSelectorToken when selector like `template, /* 1 */ [hidden]`, comment bewteen two selector, and second selector start with `[`, compiled result is `template, /* 1 */ [[hidden]`,it get one more `[` to cause the bug